### PR TITLE
Public Client: Get Symbol Details

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ r = gemini.PublicClient(sandbox=True)
 ```python
 r.symbols()
 ```
+- [symbol_details](https://docs.gemini.com/rest-api/#symbol-details)
+```python
+r.symbol_details("BTCUSD")
+```
 - [get_ticker](https://docs.gemini.com/rest-api/#ticker)
 ```python
 r.get_ticker("BTCUSD")

--- a/gemini/public_client.py
+++ b/gemini/public_client.py
@@ -30,6 +30,31 @@ class PublicClient(metaclass=Cached):
         return r.json()
 
     @typeassert(product_id=str)
+    def symbol_details(self, product_id):
+        """
+        This endpoint retrieves extra detail on supported symbols, such as 
+        minimum order size, tick size, quote increment and more.
+
+        Args:
+            product_id(str): Can be any value in self.symbols()
+
+        Returns:
+            dict:tick_size, quote_increment, min_order_size, status and wrap_enabled
+            example: {
+                "symbol":"BTCUSD",
+                "base_currency":"BTC",
+                "quote_currency":"USD",
+                "tick_size":1e-08,
+                "quote_increment":0.01,
+                "min_order_size":"0.00001",
+                "status":"open",
+                "wrap_enabled":false
+            }
+        """
+        r = requests.get(self.public_base_url + '/symbols/details/' + product_id)
+        return r.json()
+
+    @typeassert(product_id=str)
     def get_ticker(self, product_id):
         """
         This endpoint retrieves information about recent trading

--- a/tests/test_public_client.py
+++ b/tests/test_public_client.py
@@ -44,3 +44,16 @@ class TestPublicClient:
         r = client()
         symbols = r.symbols()
         assert type(symbols) is list
+
+    def test_symbol_details(self):
+        r = client()
+        symbol_details = r.symbol_details("BTCUSD")
+        assert type(symbol_details) is dict
+        assert "symbol" in symbol_details
+        assert "base_currency" in symbol_details
+        assert "quote_currency" in symbol_details
+        assert "tick_size" in symbol_details
+        assert "quote_increment" in symbol_details
+        assert "min_order_size" in symbol_details
+        assert "status" in symbol_details
+        assert "wrap_enabled" in symbol_details


### PR DESCRIPTION
Adding support for https://docs.gemini.com/rest-api/#symbol-details